### PR TITLE
Fix translation for credit memo

### DIFF
--- a/es_ES/all.csv
+++ b/es_ES/all.csv
@@ -3657,7 +3657,7 @@
 "Total Due","Total debido","module","Magento_Sales"
 "Edit","Editar","module","Magento_Sales"
 "Are you sure you want to send an order email to customer?","¿Realmente quiere enviar al cliente un mensaje electrónico de pedido?","module","Magento_Sales"
-"This will create an offline refund. To create an online refund, open an invoice and create credit memo for it. Do you want to continue?","Esto creará un reembolso sin conexión. ' ' Para crear un reembolso en línea, abrir una factura y crear abono para él. ¿Desea continuar?","module","Magento_Sales"
+"This will create an offline refund. To create an online refund, open an invoice and create credit memo for it. Do you want to continue?","Esto creará un reembolso sin conexión. Para crear un reembolso en línea, abrir una factura y crear abono para él. ¿Desea continuar?","module","Magento_Sales"
 "Are you sure you want to void the payment?","¿Realmente quiere anular el pago?","module","Magento_Sales"
 "Hold","Retener","module","Magento_Sales"
 "hold","Retener","module","Magento_Sales"


### PR DESCRIPTION
The translation caused an error in the first parameter of Javascript function when created Credit Memo of order in admin panel.

Js function before: 
confirmSetLocation('Esto creará un reembolso sin conexión. ' ' Para crear un reembolso en línea, abrir una factura y crear abono para él. ¿Desea continuar?', '....